### PR TITLE
Adding linkFrom to ingester

### DIFF
--- a/lib/graphql/ingester/sonarScan.graphql
+++ b/lib/graphql/ingester/sonarScan.graphql
@@ -1,7 +1,7 @@
 type SonarScan @rootType {
     analysedAt: String!
     project: SonarProject!
-    properties: SonarProjectProperties!
+    properties(sonar_analysis_scmBranch: String, sonar_analysis_scmRevision: String): SonarProjectProperties!
     qualityGate: SonarQualityGate!
     serverUrl: String!
     status: String!
@@ -12,6 +12,14 @@ type SonarScan @rootType {
             variables: [
                 {name: "afterSha", path: "$.properties.sonar_analysis_scmRevision"},
                 {name: "branchName", path: "$.properties.sonar_analysis_scmBranch"}
+            ]
+        )
+        @linkFrom(
+            field: { kind: LIST, name: "sonarScan" }
+            query: "query sonarScan($sha: String!, $branch: String!) {SonarScan { properties(sonar_analysis_scmBranch: $branch, sonar_analysis_scmRevision:$sha) { sonar_analysis_scmBranch sonar_analysis_scmRevision}}}"
+            variables: [
+                { name: "sha", path: "$.after.sha" }
+                { name: "branch", path: "$.branch" }
             ]
         )
 }


### PR DESCRIPTION

Adding linkFrom to the ingester to provide a better audit trail off the
push.  This will allow easily seeing if a particular commit was scanned
and what the result of the quality gate was (plus other metrics, etc).