### PR TITLE
Apply target for lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5900,9 +5900,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "version": "4.17.15",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/atomist/sdm-pack-sonarqube/issues"
   },
   "dependencies": {
-    "lodash": "^4.17.11",
+    "lodash": "^4.17.15",
     "@types/lodash": "^4.14.118"
   },
   "peerDependencies": {


### PR DESCRIPTION
Apply target `npm-project-deps::lodash`:

**New NPM Package Version Update**
Target version for NPM package *lodash* is `^4.17.15`.
Project *atomist/sdm-pack-sonarqube/master* is currently using version `^4.17.11`.

_NPM dependencies_
```lodash (^4.17.15)```

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:npm-project-deps::lodash=67e0a6b0cd3b8a665eef8a872abba84502cced775efba0711ee6e1a3ba51698b]</code>
</details>